### PR TITLE
Modal Background Z-INDEX issue

### DIFF
--- a/less/modals.less
+++ b/less/modals.less
@@ -64,7 +64,7 @@
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: @zindex-modal-background;
+  /*z-index: @zindex-modal-background;*/ /* CAUSES MODAL BACKGROUND TO BE IN FRONT OF MODAL DIALOG */
   background-color: @modal-backdrop-bg;
   // Fade for backdrop
   &.fade { .opacity(0); }


### PR DESCRIPTION
This line is not needed and needs to be removed.
Line 67:   z-index: @zindex-modal-background; /\* CAUSES MODAL BACKGROUND TO BE IN FRONT OF MODAL DIALOG */
